### PR TITLE
Using FindX11 module in CMake to link required X11 libraries. Library…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,8 +42,10 @@ add_library(os ${os_sources} ${os_headers})
 target_compile_features(os PUBLIC cxx_std_17)
 
 if (UNIX)
+    find_package( X11 REQUIRED )
+
     # Library to manipulate GUI on linux
-    target_link_libraries(os PRIVATE "-lX11" "-lXtst")
+    target_link_libraries(os PUBLIC X11::Xtst X11::X11)
 endif()
 
 # Specify directories which the compiler should look for headers


### PR DESCRIPTION
Me again :)

I think it is better to use built-in modules in CMake to link libraries rather than hard-coding by hand. So I opened another pr. X11 module offers other X11 libraries too, here is the link https://cmake.org/cmake/help/latest/module/FindX11.html

I made linkage public, so it will expose transitively to libos consumers'.